### PR TITLE
Fixes after implementing for production use.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       array_enumerator (~> 0.0.6)
       haml
       jquery-rails
-      rails (>= 4.0.0)
+      rails (>= 3.1.2)
       string-cases
 
 GEM

--- a/app/controllers/awesome_translations/groups_controller.rb
+++ b/app/controllers/awesome_translations/groups_controller.rb
@@ -21,7 +21,9 @@ class AwesomeTranslations::GroupsController < AwesomeTranslations::ApplicationCo
       end
     end
 
-    render nothing: true
+    I18n.backend.reload!
+
+    redirect_to handler_group_path(@handler, @group)
   end
 
 private

--- a/app/models/awesome_translations/translated_value.rb
+++ b/app/models/awesome_translations/translated_value.rb
@@ -32,7 +32,11 @@ class AwesomeTranslations::TranslatedValue
       key_part = key_part.to_s
 
       if index == last_index
-        current[key_part] = value
+        if @value.empty?
+          current.delete(key_part)
+        else
+          current[key_part] = value
+        end
       else
         current[key_part] ||= {}
         current = current[key_part]

--- a/app/models/awesome_translations/translation.rb
+++ b/app/models/awesome_translations/translation.rb
@@ -28,7 +28,7 @@ class AwesomeTranslations::Translation
 
       translated_value = AwesomeTranslations::TranslatedValue.new(
         file: "#{dir}/#{locale}.yml",
-        key: key,
+        key: @key,
         locale: locale,
         value: value(locale: locale)
       )
@@ -40,21 +40,21 @@ class AwesomeTranslations::Translation
   def translated_value_for_locale(locale)
     AwesomeTranslations::TranslatedValue.new(
       file: "#{dir}/#{locale}.yml",
-      key: key,
+      key: @key,
       locale: locale,
       value: value_for?(locale) ? value(locale: locale) : ""
     )
   end
 
   def value_for?(locale)
-    I18n.exists?(key, locale: locale)
+    I18n.with_locale(locale) { return I18n.exists?(@key) }
   end
 
   def value(args = {})
-    locale = args[:locale] || I18n.locale || I18n.default_locale
+    locale = (args[:locale] || I18n.locale || I18n.default_locale).to_sym
 
     return nil unless value_for?(locale)
-    I18n.t(key, locale: locale)
+    I18n.with_locale(locale) { return I18n.t(@key) }
   end
 
   def to_s

--- a/awesome_translations.gemspec
+++ b/awesome_translations.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 4.0.0"
+  s.add_dependency "rails", ">= 3.1.2"
   s.add_dependency "string-cases"
   s.add_dependency "jquery-rails"
   s.add_dependency "haml"

--- a/lib/awesome_translations.rb
+++ b/lib/awesome_translations.rb
@@ -1,6 +1,7 @@
 require "awesome_translations/engine"
 require "haml"
 require "string-cases"
+require "array_enumerator"
 
 module AwesomeTranslations
   autoload :Handlers, "#{File.dirname(__FILE__)}/awesome_translations/handlers"
@@ -8,4 +9,4 @@ module AwesomeTranslations
   autoload :ModelInspector, "awesome_translations/model_inspector"
 end
 
-Object.include AwesomeTranslations::ObjectExtensions
+Object.__send__(:include, AwesomeTranslations::ObjectExtensions)

--- a/lib/awesome_translations/model_inspector.rb
+++ b/lib/awesome_translations/model_inspector.rb
@@ -9,7 +9,12 @@ class AwesomeTranslations::ModelInspector
     ::Rails.application.eager_load!
 
     ::Object.constants.each do |clazz|
-      clazz = clazz.to_s.constantize
+      begin
+        clazz = clazz.to_s.constantize
+      rescue NameError
+        next # Ignore and continue to next class.
+      end
+
       next unless clazz.class == Class
       next unless clazz < ActiveRecord::Base
 

--- a/spec/dummy/app/views/users/_partial_test.html.haml
+++ b/spec/dummy/app/views/users/_partial_test.html.haml
@@ -1,0 +1,1 @@
+= t(".partial_test")

--- a/spec/handlers/erb_handler_spec.rb
+++ b/spec/handlers/erb_handler_spec.rb
@@ -19,6 +19,11 @@ describe AwesomeTranslations::Handlers::ErbHandler do
     danish_translations.length.should eq 1
   end
 
+  it "doesnt include _ in partial keys" do
+    partial_test = translations.select { |t| t.key == "views.users.partial_test.partial_test" }
+    partial_test.length.should eq 1
+  end
+
   it "removes special characters when using the custom method" do
     current_language_translation = translations.select { |t| t.key == "views.layouts.application.the_current_language_is" }
     current_language_translation.length.should eq 1


### PR DESCRIPTION
Fixed loading of array enumerator.
Skip constants that cannot be loaded or read instead of crashing.
Fixed setting non-given translations as empty strings.
Fixed checking for existing translations.
Redirect back to translations-page after save.
Reload translations after save.
Fixed same translation being showed multiple times in list.
Sorts ERB translations.
Fixed removal of _ in partial keys.